### PR TITLE
release: v0.1.1 — plugin management, CLI detection, help system

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,9 @@ jobs:
       - name: Install system dependencies
         run: |
           brew install ffmpeg pkg-config
-          echo "PKG_CONFIG_PATH=$(brew --prefix ffmpeg)/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
+          FFMPEG_PREFIX=$(brew --prefix ffmpeg)
+          echo "PKG_CONFIG_PATH=${FFMPEG_PREFIX}/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
+          echo "LIBRARY_PATH=${FFMPEG_PREFIX}/lib:${LIBRARY_PATH:-}" >> $GITHUB_ENV
 
       - name: Clippy
         working-directory: reeln-dock/src-tauri

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,25 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-04-23
+
 ### Added
 
-- CI pipeline with GitHub Actions (frontend checks, Rust lint/test, multi-platform)
+- In-app plugin update via `reeln plugins update` — registry badges trigger upgrades directly
+- "Update All" button on registry page when plugin updates are available
+- In-app plugin uninstall via `reeln plugins uninstall` with two-click confirmation
+- Search/filter on the plugin registry page (by name and description)
+- Robust cross-platform CLI detection — searches pyenv, uv, pipx, Homebrew, cargo, and login shell PATH
+- Windows CLI detection — checks USERPROFILE, APPDATA, LOCALAPPDATA Python paths
+- CLI binary validation with `--version` before accepting (catches broken pyenv shims)
+- CI pipeline with GitHub Actions (frontend checks, Rust lint/test, multi-platform including Windows)
 - Release workflow with tag-triggered builds for macOS, Linux, and Windows
 - SHA-256 checksum generation for all release artifacts
-- Windows `.ico` icon for platform bundling
 - Comprehensive CLI logging — all `reeln` CLI commands, stdout, stderr, and exit codes piped to log viewer
-- Backend-to-frontend log bridge via Tauri events (`dock:log`)
-- Help tooltips with ReadTheDocs links on render profile settings and rendering options
-- `HelpLink` component for inline contextual help throughout the UI
-- Help text registry (`src/lib/help.ts`) mapping settings to documentation URLs
-- SECURITY.md, CONTRIBUTING.md, issue templates, PR template
-- GitHub Discussions enabled, branch protection on `main`, Dependabot alerts
+- Help tooltips with ReadTheDocs links across every screen (72 entries)
+- Native menu bar with Help (docs, issues, discussions), View (Cmd+1-4), keyboard shortcuts
+- About dialog with project info, icon, and credits
+- Automatic update checker for dock, CLI, and installed plugins (once per day)
+- Plugin update badges on registry page with version info
+- SECURITY.md, CONTRIBUTING.md, issue templates, PR template, GitHub Discussions
 
 ### Fixed
 
-- All `svelte-check` type errors (unused imports, test fixture types)
-- All `cargo clippy` warnings (`field_reassign_with_default`, collapsible `if`, clamp pattern)
-- Rust formatting across the codebase
+- CLI detection on macOS — Tauri apps don't inherit shell PATH; now searches common install locations directly
+- User-friendly "CLI not found" error message with `pip install` instructions and docs link
+- All `svelte-check` type errors and `cargo clippy` warnings
+- macOS Gatekeeper note in release instructions
 
 ## [0.1.0] - 2026-04-21
 
@@ -65,5 +74,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Create render entry when CLI iteration path doesn't save to game.json
 - Render iteration per-profile via CLI enforcing CLI-parity mandate
 
-[Unreleased]: https://github.com/StreamnDad/reeln-dock/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/StreamnDad/reeln-dock/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/StreamnDad/reeln-dock/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/StreamnDad/reeln-dock/releases/tag/v0.1.0

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "reeln-dock",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3043,7 +3043,7 @@ dependencies = [
 
 [[package]]
 name = "reeln-dock"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "chrono",
  "filetime",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reeln-dock"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license = "AGPL-3.0-only"
 description = "Cross-platform desktop app for the reeln ecosystem"

--- a/src-tauri/src/orchestration/hook_executor.rs
+++ b/src-tauri/src/orchestration/hook_executor.rs
@@ -122,14 +122,12 @@ pub fn detect_reeln_cli(explicit_path: Option<&str>) -> Result<String, String> {
         }
     }
 
-    Err(
-        "reeln CLI not found.\n\n\
+    Err("reeln CLI not found.\n\n\
          Install with: pip install reeln\n\
          Or: python -m pip install reeln\n\n\
          Then restart reeln dock, or set the CLI path manually in Settings.\n\n\
          See: https://reeln-cli.readthedocs.io/en/latest/install.html"
-            .to_string(),
-    )
+        .to_string())
 }
 
 /// Validate that a candidate CLI binary actually runs (not a broken shim).

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui-org/nicegui/main/nicegui/static/tauri.conf.schema.json",
   "productName": "reeln dock",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "identifier": "dad.streamn.reeln-dock",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

Patch release with plugin management parity, robust CLI detection, and the full help/docs system.

- **Plugin update/uninstall** — registry badges now trigger in-app updates via `reeln plugins update`, uninstall with two-click confirmation, "Update All" button, search/filter
- **CLI detection** — searches pyenv, uv, pipx, Homebrew, cargo, system paths, and login shell; validates candidates with `--version`; Windows paths for Python 3.10-3.13
- **Help system** — 72 contextual tooltips linking to ReadTheDocs, native menu bar with Help/View/File, About dialog, update checker for dock + CLI + plugins
- **CI/CD** — GitHub Actions for Linux, macOS, Windows; tag-triggered release builds with checksums

### Stats
- 294 Rust tests + 110 frontend tests
- 0 svelte-check errors, 0 clippy warnings

## Test plan

- [x] `npm run check` — 0 errors
- [x] `npm run test` — 110 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo test` — 294 tests pass
- [ ] Verify CI passes on all 4 platforms
- [ ] Smoke test plugin update/uninstall in `cargo tauri dev`


🤖 Generated with [Claude Code](https://claude.com/claude-code)